### PR TITLE
Update CliSyntax for ModBook prefixes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,4 +12,12 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
+    //ModBook Prefixes
+    public static final Prefix PREFIX_CODE = new Prefix("c/");
+    public static final Prefix PREFIX_DAY = new Prefix("d/");
+    public static final Prefix PREFIX_START = new Prefix("s/");
+    public static final Prefix PREFIX_END = new Prefix("e/");
+    public static final Prefix PREFIX_LINK = new Prefix("l/");
+    public static final Prefix PREFIX_VENUE = new Prefix("v/");
+
 }


### PR DESCRIPTION
Keep old AB3 prefixes so that it can compile, but have to delete later