### PR TITLE
Fix bug in parseVenue

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -213,7 +213,7 @@ public class ParserUtil {
     public static Venue parseVenue(String venueName) throws ParseException {
         requireNonNull(venueName);
         String trimmedVenueName = venueName.trim();
-        if (!ExamName.isValidExamName(trimmedVenueName)) {
+        if (!Venue.isValidVenue(trimmedVenueName)) {
             throw new ParseException(Venue.MESSAGE_CONSTRAINTS);
         }
         return new Venue(trimmedVenueName);


### PR DESCRIPTION
`parseVenue` called `isValidExamName` instead of `isValidVenue`.