### PR TITLE
Pass GuiState from MainWindow to Parser

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -17,11 +18,12 @@ public interface Logic {
     /**
      * Executes the command and returns the result.
      * @param commandText The command as entered by the user.
+     * @param guiState The current state of the GUI.
      * @return the result of the command execution.
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException If an error occurs during parsing.
      */
-    CommandResult execute(String commandText) throws CommandException, ParseException;
+    CommandResult execute(String commandText, GuiState guiState) throws CommandException, ParseException;
 
     /**
      * Returns the AddressBook.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -9,6 +9,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -38,11 +39,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
+    public CommandResult execute(String commandText, GuiState guiState) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = addressBookParser.parseCommand(commandText);
+        Command command = addressBookParser.parseCommand(commandText, guiState);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -15,7 +15,7 @@ public class CommandResult {
     private final boolean showHelp;
 
     /** State of the application. */
-    private final State state;
+    private final GuiState guiState;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
@@ -23,16 +23,16 @@ public class CommandResult {
     public CommandResult(String feedbackToUser, boolean showHelp) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
-        this.state = State.SUMMARY;
+        this.guiState = GuiState.SUMMARY;
     }
 
     /**
      * Constructs a {@code CommandResult} with the specified fields (includes state argument).
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, State state) {
+    public CommandResult(String feedbackToUser, boolean showHelp, GuiState guiState) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
-        this.state = state;
+        this.guiState = guiState;
     }
 
     /**
@@ -51,8 +51,8 @@ public class CommandResult {
         return showHelp;
     }
 
-    public State getState() {
-        return state;
+    public GuiState getState() {
+        return guiState;
     }
 
     @Override
@@ -69,12 +69,12 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && state == otherCommandResult.state;
+                && guiState == otherCommandResult.guiState;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, state);
+        return Objects.hash(feedbackToUser, showHelp, guiState);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/DetailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DetailCommand.java
@@ -33,10 +33,10 @@ public class DetailCommand extends Command {
 
         if (model.getFilteredModuleList().isEmpty()) {
             model.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
-            return new CommandResult(String.format(MESSAGE_MODULE_NOT_FOUND, code), false, State.SUMMARY);
+            return new CommandResult(String.format(MESSAGE_MODULE_NOT_FOUND, code), false, GuiState.SUMMARY);
         }
 
-        return new CommandResult(String.format(MESSAGE_MODULE_DETAILS_LISTED, code), false, State.DETAILS);
+        return new CommandResult(String.format(MESSAGE_MODULE_DETAILS_LISTED, code), false, GuiState.DETAILS);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, State.EXIT);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, GuiState.EXIT);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/GuiState.java
+++ b/src/main/java/seedu/address/logic/commands/GuiState.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.commands;
 
-public enum State {
+public enum GuiState {
     EXIT, SUMMARY, DETAILS, LESSONS, EXAMS
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -29,7 +30,7 @@ public class AddCommandParser implements Parser<AddCommand> {
      * and returns an AddCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddCommand parse(String args) throws ParseException {
+    public AddCommand parse(String args, GuiState guiState) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.DetailCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -35,7 +36,7 @@ public class AddressBookParser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public Command parseCommand(String userInput, GuiState guiState) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -47,25 +47,25 @@ public class AddressBookParser {
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+            return new AddCommandParser().parse(arguments, guiState);
 
         case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+            return new EditCommandParser().parse(arguments, guiState);
 
         case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+            return new DeleteCommandParser().parse(arguments, guiState);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
+            return new FindCommandParser().parse(arguments, guiState);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
 
         case DetailCommand.COMMAND_WORD:
-            return new DetailCommandParser().parse(arguments);
+            return new DetailCommandParser().parse(arguments, guiState);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -16,7 +17,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(String args) throws ParseException {
+    public DeleteCommand parse(String args, GuiState guiState) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);

--- a/src/main/java/seedu/address/logic/parser/DetailCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DetailCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 
 import seedu.address.logic.commands.DetailCommand;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.predicates.HasModuleCodePredicate;
@@ -15,7 +16,7 @@ public class DetailCommandParser implements Parser<DetailCommand> {
      * and returns a DetailCommand for execution.
      * @throws ParseException if the user input does not conform to the expected format
      */
-    public DetailCommand parse(String args) throws ParseException {
+    public DetailCommand parse(String args, GuiState guiState) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CODE);
 
         if (!argMultimap.getValue(PREFIX_CODE).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
@@ -29,7 +30,7 @@ public class EditCommandParser implements Parser<EditCommand> {
      * and returns an EditCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public EditCommand parse(String args) throws ParseException {
+    public EditCommand parse(String args, GuiState guiState) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import java.util.Arrays;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
@@ -18,7 +19,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      * and returns a FindCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public FindCommand parse(String args) throws ParseException {
+    public FindCommand parse(String args, GuiState guiState) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -12,5 +13,5 @@ public interface Parser<T extends Command> {
      * Parses {@code userInput} into a command and returns it.
      * @throws ParseException if {@code userInput} does not conform the expected format
      */
-    T parse(String userInput) throws ParseException;
+    T parse(String userInput, GuiState guiState) throws ParseException;
 }

--- a/src/main/java/seedu/address/logic/parser/exceptions/GuiStateException.java
+++ b/src/main/java/seedu/address/logic/parser/exceptions/GuiStateException.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser.exceptions;
 
 public class GuiStateException extends ParseException {
 
-    private static String ERROR_MESSAGE = "This command cannot be used in this screen!";
+    private static final String ERROR_MESSAGE = "This command cannot be used in this screen!";
 
     public GuiStateException() {
         super(ERROR_MESSAGE);

--- a/src/main/java/seedu/address/logic/parser/exceptions/GuiStateException.java
+++ b/src/main/java/seedu/address/logic/parser/exceptions/GuiStateException.java
@@ -1,0 +1,18 @@
+package seedu.address.logic.parser.exceptions;
+
+public class GuiStateException extends ParseException {
+
+    private static String ERROR_MESSAGE = "This command cannot be used in this screen!";
+
+    public GuiStateException() {
+        super(ERROR_MESSAGE);
+    }
+
+    public GuiStateException(String message) {
+        super(message);
+    }
+
+    public GuiStateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -30,7 +30,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
-    private GuiState guiState = GuiState.SUMMARY;
+    private GuiState guiState;
 
     // Independent Ui parts residing in this Ui container
     private ModuleListPanel moduleListPanel;
@@ -61,6 +61,7 @@ public class MainWindow extends UiPart<Stage> {
         // Set dependencies
         this.primaryStage = primaryStage;
         this.logic = logic;
+        this.guiState = GuiState.SUMMARY;
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -29,6 +30,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
+    private GuiState guiState = GuiState.SUMMARY;
 
     // Independent Ui parts residing in this Ui container
     private ModuleListPanel moduleListPanel;
@@ -230,6 +232,8 @@ public class MainWindow extends UiPart<Stage> {
             default:
                 handleSummaryList();
             }
+
+            guiState = commandResult.getState();
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -204,11 +204,11 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Executes the command and returns the result.
      *
-     * @see seedu.address.logic.Logic#execute(String)
+     * @see seedu.address.logic.Logic#execute(String, GuiState)
      */
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
-            CommandResult commandResult = logic.execute(commandText);
+            CommandResult commandResult = logic.execute(commandText, guiState);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -36,6 +37,7 @@ import seedu.address.testutil.builders.PersonBuilder;
 
 public class LogicManagerTest {
     private static final IOException DUMMY_IO_EXCEPTION = new IOException("dummy exception");
+    private static final GuiState DEFAULT_STATE = GuiState.SUMMARY;
 
     @TempDir
     public Path temporaryFolder;
@@ -100,17 +102,29 @@ public class LogicManagerTest {
     }
 
     /**
-     * Executes the command and confirms that
+     * Executes the command in the given GuiState and confirms that
      * - no exceptions are thrown <br>
      * - the feedback message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in {@code expectedModel} <br>
-     * @see #assertCommandFailure(String, Class, String, Model)
+     * @see #assertCommandFailure(String, GuiState, Class, String, Model)
+     */
+    private void assertCommandSuccess(String inputCommand, GuiState guiState, String expectedMessage,
+            Model expectedModel) throws CommandException, ParseException {
+        CommandResult result = logic.execute(inputCommand, guiState);
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+        assertEquals(expectedModel, model);
+    }
+
+    /**
+     * Executes the command in the default GuiState and confirms that
+     * - no exceptions are thrown <br>
+     * - the feedback message is equal to {@code expectedMessage} <br>
+     * - the internal model manager state is the same as that in {@code expectedModel} <br>
+     * @see #assertCommandSuccess(String, GuiState, String, Model)
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage,
             Model expectedModel) throws CommandException, ParseException {
-        CommandResult result = logic.execute(inputCommand);
-        assertEquals(expectedMessage, result.getFeedbackToUser());
-        assertEquals(expectedModel, model);
+        assertCommandSuccess(inputCommand, DEFAULT_STATE, expectedMessage, expectedModel);
     }
 
     /**
@@ -140,16 +154,28 @@ public class LogicManagerTest {
     }
 
     /**
-     * Executes the command and confirms that
+     * Executes the command in the given GuiState and confirms that
      * - the {@code expectedException} is thrown <br>
      * - the resulting error message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in {@code expectedModel} <br>
-     * @see #assertCommandSuccess(String, String, Model)
+     * @see #assertCommandSuccess(String, GuiState, String, Model)
+     */
+    private void assertCommandFailure(String inputCommand, GuiState guiState,
+            Class<? extends Throwable> expectedException, String expectedMessage, Model expectedModel) {
+        assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand, guiState));
+        assertEquals(expectedModel, model);
+    }
+
+    /**
+     * Executes the command in the default GuiState and confirms that
+     * - the {@code expectedException} is thrown <br>
+     * - the resulting error message is equal to {@code expectedMessage} <br>
+     * - the internal model manager state is the same as that in {@code expectedModel} <br>
+     * @see #assertCommandFailure(String, GuiState, Class, String, Model) 
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
             String expectedMessage, Model expectedModel) {
-        assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand));
-        assertEquals(expectedModel, model);
+        assertCommandFailure(inputCommand, DEFAULT_STATE, expectedException, expectedMessage, expectedModel);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -171,7 +171,7 @@ public class LogicManagerTest {
      * - the {@code expectedException} is thrown <br>
      * - the resulting error message is equal to {@code expectedMessage} <br>
      * - the internal model manager state is the same as that in {@code expectedModel} <br>
-     * @see #assertCommandFailure(String, GuiState, Class, String, Model) 
+     * @see #assertCommandFailure(String, GuiState, Class, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
             String expectedMessage, Model expectedModel) {

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -32,7 +32,7 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("feedback", true)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, State.EXIT)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, GuiState.EXIT)));
     }
 
     @Test
@@ -49,6 +49,6 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, State.EXIT).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, GuiState.EXIT).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DetailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DetailCommandTest.java
@@ -59,7 +59,7 @@ public class DetailCommandTest {
     @Test
     public void execute_validKeyword_moduleFound() {
         String expectedMessage = String.format(MESSAGE_MODULE_DETAILS_LISTED, CS2103T.getCode());
-        CommandResult expectedResult = new CommandResult(expectedMessage, false, State.DETAILS);
+        CommandResult expectedResult = new CommandResult(expectedMessage, false, GuiState.DETAILS);
         HasModuleCodePredicate predicate = preparePredicate(CS2103T.getCode().toString());
         DetailCommand command = new DetailCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
@@ -70,7 +70,7 @@ public class DetailCommandTest {
     @Test
     public void execute_moduleNotFound_listAllModules() {
         String expectedMessage = String.format(MESSAGE_MODULE_NOT_FOUND, MA1521.getCode());
-        CommandResult expectedResult = new CommandResult(expectedMessage, false, State.SUMMARY);
+        CommandResult expectedResult = new CommandResult(expectedMessage, false, GuiState.SUMMARY);
         HasModuleCodePredicate predicate = preparePredicate(MA1521.getCode().toString());
         DetailCommand command = new DetailCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, State.EXIT);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, GuiState.EXIT);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -32,8 +32,9 @@ import seedu.address.testutil.builders.PersonBuilder;
 
 public class AddressBookParserTest {
 
+    private static final GuiState DEFAULT_STATE = GuiState.SUMMARY;
+
     private final AddressBookParser parser = new AddressBookParser();
-    private final GuiState DEFAULT_STATE = GuiState.SUMMARY;
 
     @Test
     public void parseCommand_add() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -32,24 +33,25 @@ import seedu.address.testutil.builders.PersonBuilder;
 public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
+    private final GuiState DEFAULT_STATE = GuiState.SUMMARY;
 
     @Test
     public void parseCommand_add() throws Exception {
         Person person = new PersonBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
+        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person), DEFAULT_STATE);
         assertEquals(new AddCommand(person), command);
     }
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, DEFAULT_STATE) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3", DEFAULT_STATE) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(), DEFAULT_STATE);
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
@@ -58,44 +60,47 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor),
+                DEFAULT_STATE);
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test
     public void parseCommand_exit() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, DEFAULT_STATE) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3", DEFAULT_STATE) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")),
+                DEFAULT_STATE);
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test
     public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, DEFAULT_STATE) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3", DEFAULT_STATE) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, DEFAULT_STATE) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3", DEFAULT_STATE) instanceof ListCommand);
     }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+            -> parser.parseCommand("", DEFAULT_STATE));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand",
+                DEFAULT_STATE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -14,7 +14,7 @@ public class CommandParserTestUtil {
 
     /**
      * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
-     * equals to {@code expectedCommand} based on the given {@code GuiState}
+     * equals to {@code expectedCommand} based on the given {@code GuiState}.
      */
     public static void assertParseSuccess(Parser parser, String userInput, GuiState guiState, Command expectedCommand) {
         try {
@@ -27,8 +27,8 @@ public class CommandParserTestUtil {
 
     /**
      * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
-     * equals to {@code expectedCommand}
-     * Will use the default {@code GuiState}
+     * equals to {@code expectedCommand}.
+     * Will use the default {@code GuiState}.
      */
     public static void assertParseSuccess(Parser parser, String userInput, Command expectedCommand) {
         assertParseSuccess(parser, userInput, DEFAULT_STATE, expectedCommand);
@@ -36,7 +36,7 @@ public class CommandParserTestUtil {
 
     /**
      * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
-     * equals to {@code expectedMessage} based on the given {@code GuiState}
+     * equals to {@code expectedMessage} based on the given {@code GuiState}.
      */
     public static void assertParseFailure(Parser parser, String userInput, GuiState guiState, String expectedMessage) {
         try {
@@ -49,8 +49,8 @@ public class CommandParserTestUtil {
 
     /**
      * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
-     * equals to {@code expectedMessage} based on the given {@code GuiState}
-     * Will use the default {@code GuiState}
+     * equals to {@code expectedMessage} based on the given {@code GuiState}.
+     * Will use the default {@code GuiState}.
      */
     public static void assertParseFailure(Parser parser, String userInput, String expectedMessage) {
         assertParseFailure(parser, userInput, DEFAULT_STATE, expectedMessage);

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -3,20 +3,22 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Contains helper methods for testing command parsers.
  */
 public class CommandParserTestUtil {
+    public static GuiState DEFAULT_STATE = GuiState.SUMMARY;
 
     /**
      * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
-     * equals to {@code expectedCommand}.
+     * equals to {@code expectedCommand} based on the given {@code GuiState}
      */
-    public static void assertParseSuccess(Parser parser, String userInput, Command expectedCommand) {
+    public static void assertParseSuccess(Parser parser, String userInput, GuiState guiState, Command expectedCommand) {
         try {
-            Command command = parser.parse(userInput);
+            Command command = parser.parse(userInput, guiState);
             assertEquals(expectedCommand, command);
         } catch (ParseException pe) {
             throw new IllegalArgumentException("Invalid userInput.", pe);
@@ -24,15 +26,33 @@ public class CommandParserTestUtil {
     }
 
     /**
-     * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
-     * equals to {@code expectedMessage}.
+     * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
+     * equals to {@code expectedCommand}
+     * Will use the default {@code GuiState}
      */
-    public static void assertParseFailure(Parser parser, String userInput, String expectedMessage) {
+    public static void assertParseSuccess(Parser parser, String userInput, Command expectedCommand) {
+        assertParseSuccess(parser, userInput, DEFAULT_STATE, expectedCommand);
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
+     * equals to {@code expectedMessage} based on the given {@code GuiState}
+     */
+    public static void assertParseFailure(Parser parser, String userInput, GuiState guiState, String expectedMessage) {
         try {
-            parser.parse(userInput);
+            parser.parse(userInput, guiState);
             throw new AssertionError("The expected ParseException was not thrown.");
         } catch (ParseException pe) {
             assertEquals(expectedMessage, pe.getMessage());
         }
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
+     * equals to {@code expectedMessage} based on the given {@code GuiState}
+     * Will use the default {@code GuiState}
+     */
+    public static void assertParseFailure(Parser parser, String userInput, String expectedMessage) {
+        assertParseFailure(parser, userInput, DEFAULT_STATE, expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -10,7 +10,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Contains helper methods for testing command parsers.
  */
 public class CommandParserTestUtil {
-    public static GuiState DEFAULT_STATE = GuiState.SUMMARY;
+    public static final GuiState DEFAULT_STATE = GuiState.SUMMARY;
 
     /**
      * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created

--- a/src/test/java/seedu/address/logic/parser/DetailCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DetailCommandParserTest.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DetailCommand;
+import seedu.address.logic.commands.GuiState;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.predicates.HasModuleCodePredicate;
 
@@ -43,5 +44,10 @@ public class DetailCommandParserTest {
         // leading and trailing whitespaces
         assertParseSuccess(parser, " " + PREFIX_CODE + " \n \t " + VALID_MODULE_CODE
                 + " \n \t", expectedDetailCommand);
+
+        // parse in various GuiStates
+        assertParseSuccess(parser, VALID_MODULE_CODE_DESC, GuiState.LESSONS, expectedDetailCommand);
+        assertParseSuccess(parser, VALID_MODULE_CODE_DESC, GuiState.EXAMS, expectedDetailCommand);
+        assertParseSuccess(parser, VALID_MODULE_CODE_DESC, GuiState.DETAILS, expectedDetailCommand);
     }
 }


### PR DESCRIPTION
Now `MainWindow` passes in `GuiState` to `AddressBookParser` so we can limit commands based on `GuiState`!

Let's:
- Rename `State` to `GuiState` and refactor accordingly
- Create a `GuiState` field in `MainWindow`
- Use `GuiState` as a parameter for the various `execute` and `parse` methods
- Create a new `GuiStateException` that extends `ParseException`
- Adjust tests accordingly to take `GuiState` into account