### PR TITLE
Add more valid Time formats

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -5,7 +5,7 @@ NUS ModBook is a **desktop app for managing modules, optimized for use via a Com
 
 ## Table of Contents
 1. [Quick Start](#Quick-start)
-1. [Features](#Features)
+2. [Features](#Features)
     * [Modules](#Modules)
         * [Adding a module](#Adding-a-module-add-mod)
         * [Listing all modules](#Listing-all-modules--list-mod)
@@ -28,8 +28,9 @@ NUS ModBook is a **desktop app for managing modules, optimized for use via a Com
         * [Exiting the program](#Exiting-the-program--exit)
         * [Saving the data](#Saving-the-data)
         * [Editing the data file](#Editing-the-data-file)
-1. [FAQ](#FAQ)
-1. [Command Summary](#Command-Summary)
+3. [FAQ](#FAQ)
+4. [Date and time formats](#Date-and-time-formats)
+5. [Command Summary](#Command-Summary)
     * [By Action](#Command-Summary-by-Action)
     * [By Object](#Command-Summary-by-Object)
 
@@ -49,7 +50,7 @@ NUS ModBook is a **desktop app for managing modules, optimized for use via a Com
 
 
 ## Features
-#### Notes about the command format:
+### Notes about the command format:
 * Words in UPPER_CASE are the parameters to be supplied by the user.
   e.g. in add `c/CODE`, `CODE` is a parameter which can be used as `add mod c/CS2103T`.
 * Items in square brackets are optional.
@@ -160,11 +161,36 @@ ModBook data is saved as a JSON file `[JAR file location]/data/modbook.json`. Ad
 Caution: If your changes to the data file makes its format invalid, ModBook will discard all data and start with an empty data file at the next run.
 
 ## FAQ
-**Q**:   How do I transfer my data to another Computer?
+**Q**:   How do I transfer my data to another Computer?  
 **A**:   Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous ModBook home folder.
+
+## Date and time formats
+The following formats are valid for entering time values:
+
+| Format   | Examples             |
+|----------|----------------------|
+| `HH:mm`  | `09:00`, `14:30`     |
+| `HH.mm`  | `09.00`, `14.30`     |
+| `HHmm`   | `0900`, `1430`       |
+| `ha`     | `9AM`, `2pm`         |
+| `hha`    | `09AM`, `11pm`       |
+| `h:mma`  | `9:00AM`, `2:30pm`   |
+| `hh:mma` | `09:00AM`, `11:30pm` |
+| `h.mma`  | `9.00AM`, `2.30pm`   |
+| `hh.mma` | `09.00AM`, `11.30pm` |
+
+The meaning of the symbols in the formats specified are in the table below:
+
+| Symbol | Meaning                                 |
+|--------|-----------------------------------------|
+| H      | Hour of 24-hour time. Goes from 0 to 23 |
+| h      | Hour of 12-hour time. Goes from 1 to 12 |
+| m      | Minute                                  |
+| a      | AM/PM indicator                         |
 
 ## Command Summary
 ### Command Summary by Action
+
 | Action | Object | Format, Examples                                                                                                         |
 |--------|--------|--------------------------------------------------------------------------------------------------------------------------|
 | Add    | Module | `add mod c/CODE [n/NAME]`                                                                                                  |
@@ -185,6 +211,7 @@ Caution: If your changes to the data file makes its format invalid, ModBook will
 | Exit   |        | `exit`                                                                                                                     |
 
 ### Command Summary by Object
+
 | Object | Action | Format, Examples                                                                                                         |
 |--------|--------|--------------------------------------------------------------------------------------------------------------------------|
 | Module | Add    | `add mod c/CODE [n/NAME]`                                                                                                  |

--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -1,0 +1,17 @@
+package seedu.address.commons.util;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+public class DateTimeUtil {
+
+    /**
+     * Returns a case-insensitive DateTimeFormatter according to the given pattern
+     */
+    public static DateTimeFormatter buildFormatter(String pattern) {
+        return new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .appendPattern(pattern)
+                .toFormatter();
+    }
+}

--- a/src/main/java/seedu/address/model/module/ModBookTime.java
+++ b/src/main/java/seedu/address/model/module/ModBookTime.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 
 /**
@@ -16,15 +17,15 @@ public class ModBookTime implements Comparable<ModBookTime> {
             "Invalid time format. Please refer to the User Guide for valid time formats.";
     public static final DateTimeFormatter PARSE_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     public static final DateTimeFormatter[] PARSE_FORMATTERS = new DateTimeFormatter[] {
-            DateTimeFormatter.ofPattern("HH:mm"), // 09:30, 14:30
-            DateTimeFormatter.ofPattern("HH.mm"), // 09.30, 14.30
-            DateTimeFormatter.ofPattern("HHmm"), // 0930, 1430
-            DateTimeFormatter.ofPattern("ha"), // 9AM, 4PM
-            DateTimeFormatter.ofPattern("hha"), // 11AM, 04PM
-            DateTimeFormatter.ofPattern("h:mma"), // 9:30AM, 4:00PM
-            DateTimeFormatter.ofPattern("hh:mma"), // 11:30AM, 04:00PM
-            DateTimeFormatter.ofPattern("h.mma"), // 9.30AM, 4.00PM
-            DateTimeFormatter.ofPattern("hh.mma") // 11.30AM, 04.00PM
+            buildFormatter("HH:mm"), // 09:30, 14:30
+            buildFormatter("HH.mm"), // 09.30, 14.30
+            buildFormatter("HHmm"), // 0930, 1430
+            buildFormatter("ha"), // 9AM, 4PM
+            buildFormatter("hha"), // 11AM, 04PM
+            buildFormatter("h:mma"), // 9:30AM, 4:00PM
+            buildFormatter("hh:mma"), // 11:30AM, 04:00PM
+            buildFormatter("h.mma"), // 9.30AM, 4.00PM
+            buildFormatter("hh.mma") // 11.30AM, 04.00PM
     };
     public static final DateTimeFormatter PRINT_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     public final LocalTime time;
@@ -46,6 +47,16 @@ public class ModBookTime implements Comparable<ModBookTime> {
 
     public ModBookTime deepCopy() {
         return new ModBookTime(time);
+    }
+
+    /**
+     * Returns a case-insensitive DateTimeFormatter according to the given pattern
+     */
+    private static DateTimeFormatter buildFormatter(String pattern) {
+        return new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .appendPattern(pattern)
+                .toFormatter();
     }
 
     /**

--- a/src/main/java/seedu/address/model/module/ModBookTime.java
+++ b/src/main/java/seedu/address/model/module/ModBookTime.java
@@ -2,10 +2,10 @@ package seedu.address.model.module;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.DateTimeUtil.buildFormatter;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 
 /**
@@ -47,16 +47,6 @@ public class ModBookTime implements Comparable<ModBookTime> {
 
     public ModBookTime deepCopy() {
         return new ModBookTime(time);
-    }
-
-    /**
-     * Returns a case-insensitive DateTimeFormatter according to the given pattern
-     */
-    private static DateTimeFormatter buildFormatter(String pattern) {
-        return new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                .appendPattern(pattern)
-                .toFormatter();
     }
 
     /**

--- a/src/main/java/seedu/address/model/module/ModBookTime.java
+++ b/src/main/java/seedu/address/model/module/ModBookTime.java
@@ -53,7 +53,7 @@ public class ModBookTime implements Comparable<ModBookTime> {
      */
     public static boolean isValidTime(String test) {
         requireNonNull(test);
-        return tryParse(test) == null;
+        return tryParse(test) != null;
     }
 
     /**

--- a/src/main/java/seedu/address/model/module/ModBookTime.java
+++ b/src/main/java/seedu/address/model/module/ModBookTime.java
@@ -15,7 +15,6 @@ import java.time.format.DateTimeParseException;
 public class ModBookTime implements Comparable<ModBookTime> {
     public static final String MESSAGE_CONSTRAINTS =
             "Invalid time format. Please refer to the User Guide for valid time formats.";
-    public static final DateTimeFormatter PARSE_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     public static final DateTimeFormatter[] PARSE_FORMATTERS = new DateTimeFormatter[] {
             buildFormatter("HH:mm"), // 09:30, 14:30
             buildFormatter("HH.mm"), // 09.30, 14.30

--- a/src/main/java/seedu/address/model/module/ModBookTime.java
+++ b/src/main/java/seedu/address/model/module/ModBookTime.java
@@ -13,8 +13,19 @@ import java.time.format.DateTimeParseException;
  */
 public class ModBookTime implements Comparable<ModBookTime> {
     public static final String MESSAGE_CONSTRAINTS =
-            "Times should be in the format of hh:mm in 24 hour time";
+            "Invalid time format. Please refer to the User Guide for valid time formats.";
     public static final DateTimeFormatter PARSE_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    public static final DateTimeFormatter[] PARSE_FORMATTERS = new DateTimeFormatter[] {
+            DateTimeFormatter.ofPattern("HH:mm"), // 09:30, 14:30
+            DateTimeFormatter.ofPattern("HH.mm"), // 09.30, 14.30
+            DateTimeFormatter.ofPattern("HHmm"), // 0930, 1430
+            DateTimeFormatter.ofPattern("ha"), // 9AM, 4PM
+            DateTimeFormatter.ofPattern("hha"), // 11AM, 04PM
+            DateTimeFormatter.ofPattern("h:mma"), // 9:30AM, 4:00PM
+            DateTimeFormatter.ofPattern("hh:mma"), // 11:30AM, 04:00PM
+            DateTimeFormatter.ofPattern("h.mma"), // 9.30AM, 4.00PM
+            DateTimeFormatter.ofPattern("hh.mma") // 11.30AM, 04.00PM
+    };
     public static final DateTimeFormatter PRINT_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     public final LocalTime time;
 
@@ -26,7 +37,7 @@ public class ModBookTime implements Comparable<ModBookTime> {
     public ModBookTime(String time) {
         requireNonNull(time);
         checkArgument(isValidTime(time), MESSAGE_CONSTRAINTS);
-        this.time = LocalTime.parse(time, PARSE_FORMATTER);
+        this.time = tryParse(time);
     }
 
     private ModBookTime(LocalTime time) {
@@ -42,12 +53,24 @@ public class ModBookTime implements Comparable<ModBookTime> {
      */
     public static boolean isValidTime(String test) {
         requireNonNull(test);
-        try {
-            LocalTime.parse(test, PARSE_FORMATTER);
-            return true;
-        } catch (DateTimeParseException e) {
-            return false;
+        return tryParse(test) == null;
+    }
+
+    /**
+     * Tries to parse a given string with various DateTimeFormatters.
+     * Returns a LocalTime if parsing was successful,  null otherwise.
+     */
+    public static LocalTime tryParse(String test) {
+        requireNonNull(test);
+        LocalTime result = null;
+        for (DateTimeFormatter f : PARSE_FORMATTERS) {
+            try {
+                result = LocalTime.parse(test, f);
+            } catch (DateTimeParseException e) {
+                // do nothing
+            }
         }
+        return result;
     }
 
     /**

--- a/src/main/java/seedu/address/model/module/ModBookTime.java
+++ b/src/main/java/seedu/address/model/module/ModBookTime.java
@@ -37,7 +37,7 @@ public class ModBookTime implements Comparable<ModBookTime> {
     public ModBookTime(String time) {
         requireNonNull(time);
         checkArgument(isValidTime(time), MESSAGE_CONSTRAINTS);
-        this.time = tryParse(time);
+        this.time = parseTime(time);
     }
 
     private ModBookTime(LocalTime time) {
@@ -53,14 +53,14 @@ public class ModBookTime implements Comparable<ModBookTime> {
      */
     public static boolean isValidTime(String test) {
         requireNonNull(test);
-        return tryParse(test) != null;
+        return parseTime(test) != null;
     }
 
     /**
      * Tries to parse a given string with various DateTimeFormatters.
      * Returns a LocalTime if parsing was successful,  null otherwise.
      */
-    public static LocalTime tryParse(String test) {
+    public static LocalTime parseTime(String test) {
         requireNonNull(test);
         LocalTime result = null;
         for (DateTimeFormatter f : PARSE_FORMATTERS) {

--- a/src/main/java/seedu/address/model/module/ModBookTime.java
+++ b/src/main/java/seedu/address/model/module/ModBookTime.java
@@ -66,6 +66,7 @@ public class ModBookTime implements Comparable<ModBookTime> {
         for (DateTimeFormatter f : PARSE_FORMATTERS) {
             try {
                 result = LocalTime.parse(test, f);
+                break; // short circuit once valid formatter is found
             } catch (DateTimeParseException e) {
                 // do nothing
             }

--- a/src/main/java/seedu/address/storage/JsonAdaptedModBookTime.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModBookTime.java
@@ -25,7 +25,7 @@ public class JsonAdaptedModBookTime {
      * Converts a given {@code ModBookTime} into this class for Jackson use.
      */
     public JsonAdaptedModBookTime(ModBookTime source) {
-        time = source.time.format(ModBookTime.PARSE_FORMATTER); // in parsing format so that it can be parsed correctly
+        time = source.time.format(ModBookTime.PARSE_FORMATTERS[0]); // so that it can be parsed correctly
     }
 
     @JsonValue

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -90,8 +90,8 @@ public class CommandTestUtil {
     public static final String INVALID_DAY_DESC = " " + PREFIX_DAY + "jupiter";
     public static final String INVALID_DATE_DESC = " " + PREFIX_DAY + "mon";
     public static final String INVALID_LINK_DESC = " " + PREFIX_LINK + "";
-    public static final String INVALID_START_TIME_DESC = " " + PREFIX_START + "1000";
-    public static final String INVALID_END_TIME_DESC = " " + PREFIX_END + "1000";
+    public static final String INVALID_START_TIME_DESC = " " + PREFIX_START + "100";
+    public static final String INVALID_END_TIME_DESC = " " + PREFIX_END + "100";
     public static final String INVALID_VENUE_DESC = " " + PREFIX_VENUE + "";
 
     public static final String RANDOM_TEXT = " " + "momo";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -42,7 +42,7 @@ public class ParserUtilTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_LINK = " ";
-    private static final String INVALID_TIME = "3:00PM";
+    private static final String INVALID_TIME = "33:00PM";
     private static final String INVALID_DATE = "20/15/2022";
     private static final String INVALID_VENUE = " ";
     private static final String INVALID_EXAM_NAME = " ";
@@ -59,7 +59,7 @@ public class ParserUtilTest {
     private static final String VALID_TAG_2 = "neighbour";
     private static final String VALID_LINK = "https://www.google.com/";
     private static final String VALID_TIME_1 = "09:00";
-    private static final String VALID_TIME_2 = "11:00";
+    private static final String VALID_TIME_2 = "11am";
     private static final ModBookTime VALID_MBTIME_1 = new ModBookTime(VALID_TIME_1);
     private static final ModBookTime VALID_MBTIME_2 = new ModBookTime(VALID_TIME_2);
     private static final String VALID_DATE = "13/12/2021";

--- a/src/test/java/seedu/address/model/module/ModBookTimeTest.java
+++ b/src/test/java/seedu/address/model/module/ModBookTimeTest.java
@@ -1,9 +1,12 @@
 package seedu.address.model.module;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalTime;
 import org.junit.jupiter.api.Test;
 
 class ModBookTimeTest {
@@ -29,10 +32,9 @@ class ModBookTimeTest {
         assertFalse(ModBookTime.isValidTime(" "));
 
         // invalid time formats
-        assertFalse(ModBookTime.isValidTime("4:00pm")); // use of AM/PM
-        assertFalse(ModBookTime.isValidTime("4pm")); // no minutes, use of AM/PM
-        assertFalse(ModBookTime.isValidTime("4:00")); // hours using 1 digit and not 2
+        assertFalse(ModBookTime.isValidTime("abcd")); // not a time
         assertFalse(ModBookTime.isValidTime("16")); // no minutes
+        assertFalse(ModBookTime.isValidTime("5:00")); // only one digit in hours
         assertFalse(ModBookTime.isValidTime("25:00")); // hours out of range
         assertFalse(ModBookTime.isValidTime("14:98")); // minutes out of range
         assertFalse(ModBookTime.isValidTime("16:00:01")); // including seconds value
@@ -42,5 +44,54 @@ class ModBookTimeTest {
         assertTrue(ModBookTime.isValidTime("16:00"));
         assertTrue(ModBookTime.isValidTime("08:00"));
         assertTrue(ModBookTime.isValidTime("23:59"));
+
+        // valid time formats
+        assertTrue(ModBookTime.isValidTime("23:59"));
+        assertTrue(ModBookTime.isValidTime("23.59"));
+        assertTrue(ModBookTime.isValidTime("2359"));
+        assertTrue(ModBookTime.isValidTime("1PM"));
+        assertTrue(ModBookTime.isValidTime("11PM"));
+        assertTrue(ModBookTime.isValidTime("1:59PM"));
+        assertTrue(ModBookTime.isValidTime("11:59PM"));
+        assertTrue(ModBookTime.isValidTime("1.59PM"));
+        assertTrue(ModBookTime.isValidTime("11.59PM"));
+
+    }
+
+    @Test
+    void tryParse() {
+        LocalTime expectedFourPm = LocalTime.parse("16:00");
+        LocalTime expectedElevenThirtyAm = LocalTime.parse("11:30");
+        // null time
+        assertThrows(NullPointerException.class, () -> ModBookTime.tryParse(null));
+
+        // blank time
+        assertNull(ModBookTime.tryParse(""));
+        assertNull(ModBookTime.tryParse(" "));
+
+        // invalid time formats
+        assertNull(ModBookTime.tryParse("14")); // no minutes
+        assertNull(ModBookTime.tryParse("25:00")); // hours out of range
+        assertNull(ModBookTime.tryParse("14:98")); // minutes out of range
+        assertNull(ModBookTime.tryParse("16:00:01")); // including seconds value
+        assertNull(ModBookTime.tryParse("16:00:01.1234")); // including seconds and decimal value
+        assertNull(ModBookTime.tryParse("abcd")); // not a time
+
+        // valid time formats
+        assertEquals(ModBookTime.tryParse("16:00"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("16.00"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("1600"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("4PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("04PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("4:00PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("04:00PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("4.00PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("04.00PM"), expectedFourPm);
+
+        assertEquals(ModBookTime.tryParse("11:30"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.tryParse("11.30"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.tryParse("1130"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.tryParse("11:30AM"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.tryParse("11.30AM"), expectedElevenThirtyAm);
     }
 }

--- a/src/test/java/seedu/address/model/module/ModBookTimeTest.java
+++ b/src/test/java/seedu/address/model/module/ModBookTimeTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalTime;
+
 import org.junit.jupiter.api.Test;
 
 class ModBookTimeTest {

--- a/src/test/java/seedu/address/model/module/ModBookTimeTest.java
+++ b/src/test/java/seedu/address/model/module/ModBookTimeTest.java
@@ -64,43 +64,43 @@ class ModBookTimeTest {
         LocalTime expectedFourPm = LocalTime.parse("16:00");
         LocalTime expectedElevenThirtyAm = LocalTime.parse("11:30");
         // null time
-        assertThrows(NullPointerException.class, () -> ModBookTime.tryParse(null));
+        assertThrows(NullPointerException.class, () -> ModBookTime.parseTime(null));
 
         // blank time
-        assertNull(ModBookTime.tryParse(""));
-        assertNull(ModBookTime.tryParse(" "));
+        assertNull(ModBookTime.parseTime(""));
+        assertNull(ModBookTime.parseTime(" "));
 
         // invalid time formats
-        assertNull(ModBookTime.tryParse("14")); // no minutes
-        assertNull(ModBookTime.tryParse("25:00")); // hours out of range
-        assertNull(ModBookTime.tryParse("14:98")); // minutes out of range
-        assertNull(ModBookTime.tryParse("16:00:01")); // including seconds value
-        assertNull(ModBookTime.tryParse("16:00:01.1234")); // including seconds and decimal value
-        assertNull(ModBookTime.tryParse("abcd")); // not a time
+        assertNull(ModBookTime.parseTime("14")); // no minutes
+        assertNull(ModBookTime.parseTime("25:00")); // hours out of range
+        assertNull(ModBookTime.parseTime("14:98")); // minutes out of range
+        assertNull(ModBookTime.parseTime("16:00:01")); // including seconds value
+        assertNull(ModBookTime.parseTime("16:00:01.1234")); // including seconds and decimal value
+        assertNull(ModBookTime.parseTime("abcd")); // not a time
 
         // valid time formats
-        assertEquals(ModBookTime.tryParse("16:00"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("16.00"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("1600"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("4PM"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("4pm"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("04PM"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("04pm"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("4:00PM"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("4:00pm"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("04:00PM"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("04:00pm"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("4.00PM"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("4.00pm"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("04.00PM"), expectedFourPm);
-        assertEquals(ModBookTime.tryParse("04.00pm"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("16:00"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("16.00"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("1600"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("4PM"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("4pm"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("04PM"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("04pm"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("4:00PM"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("4:00pm"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("04:00PM"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("04:00pm"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("4.00PM"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("4.00pm"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("04.00PM"), expectedFourPm);
+        assertEquals(ModBookTime.parseTime("04.00pm"), expectedFourPm);
 
-        assertEquals(ModBookTime.tryParse("11:30"), expectedElevenThirtyAm);
-        assertEquals(ModBookTime.tryParse("11.30"), expectedElevenThirtyAm);
-        assertEquals(ModBookTime.tryParse("1130"), expectedElevenThirtyAm);
-        assertEquals(ModBookTime.tryParse("11:30AM"), expectedElevenThirtyAm);
-        assertEquals(ModBookTime.tryParse("11:30am"), expectedElevenThirtyAm);
-        assertEquals(ModBookTime.tryParse("11.30AM"), expectedElevenThirtyAm);
-        assertEquals(ModBookTime.tryParse("11.30am"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.parseTime("11:30"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.parseTime("11.30"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.parseTime("1130"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.parseTime("11:30AM"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.parseTime("11:30am"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.parseTime("11.30AM"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.parseTime("11.30am"), expectedElevenThirtyAm);
     }
 }

--- a/src/test/java/seedu/address/model/module/ModBookTimeTest.java
+++ b/src/test/java/seedu/address/model/module/ModBookTimeTest.java
@@ -82,16 +82,24 @@ class ModBookTimeTest {
         assertEquals(ModBookTime.tryParse("16.00"), expectedFourPm);
         assertEquals(ModBookTime.tryParse("1600"), expectedFourPm);
         assertEquals(ModBookTime.tryParse("4PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("4pm"), expectedFourPm);
         assertEquals(ModBookTime.tryParse("04PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("04pm"), expectedFourPm);
         assertEquals(ModBookTime.tryParse("4:00PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("4:00pm"), expectedFourPm);
         assertEquals(ModBookTime.tryParse("04:00PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("04:00pm"), expectedFourPm);
         assertEquals(ModBookTime.tryParse("4.00PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("4.00pm"), expectedFourPm);
         assertEquals(ModBookTime.tryParse("04.00PM"), expectedFourPm);
+        assertEquals(ModBookTime.tryParse("04.00pm"), expectedFourPm);
 
         assertEquals(ModBookTime.tryParse("11:30"), expectedElevenThirtyAm);
         assertEquals(ModBookTime.tryParse("11.30"), expectedElevenThirtyAm);
         assertEquals(ModBookTime.tryParse("1130"), expectedElevenThirtyAm);
         assertEquals(ModBookTime.tryParse("11:30AM"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.tryParse("11:30am"), expectedElevenThirtyAm);
         assertEquals(ModBookTime.tryParse("11.30AM"), expectedElevenThirtyAm);
+        assertEquals(ModBookTime.tryParse("11.30am"), expectedElevenThirtyAm);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedModBookTimeTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedModBookTimeTest.java
@@ -9,7 +9,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.module.ModBookTime;
 
 class JsonAdaptedModBookTimeTest {
-    private static final String INVALID_TIME = "1200";
+    private static final String INVALID_TIME = "2500";
     private static final ModBookTime VALID_MODBOOKTIME = new ModBookTime("12:00");
 
     @Test


### PR DESCRIPTION
Previously the only valid time format was HH:mm. Part of Issue #85 

Let's:
* Add more valid time formats
* Create new `buildFormatter` method in `DateTimeUtil`
* Implement new `tryParse` method and update `isValidTime` and constructor
* Update tests and `JsonAdaptedModBookTime`
* Update user guide to show valid time formats