### PR TITLE
Fix bug in adding lesson and exam when using ModBook for first time

### DIFF
--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -20,8 +20,8 @@ import seedu.address.model.module.lesson.Lesson;
 public class Module {
     private final ModuleCode moduleCode;
     private final Optional<ModuleName> moduleName;
-    private final List<Lesson> lessons;
-    private final List<Exam> exams;
+    private final ArrayList<Lesson> lessons;
+    private final ArrayList<Exam> exams;
 
     /**
      * Constructs a {@code Module}
@@ -50,8 +50,10 @@ public class Module {
         requireAllNonNull(moduleCode, moduleName, lessons, exams);
         this.moduleCode = moduleCode;
         this.moduleName = moduleName;
-        this.lessons = lessons;
-        this.exams = exams;
+        this.lessons = new ArrayList<>();
+        this.lessons.addAll(lessons);
+        this.exams = new ArrayList<>();
+        this.exams.addAll(exams);
     }
 
     public ModuleCode getCode() {

--- a/src/test/java/seedu/address/model/module/lesson/LessonTest.java
+++ b/src/test/java/seedu/address/model/module/lesson/LessonTest.java
@@ -17,12 +17,12 @@ import seedu.address.model.module.Venue;
 
 public class LessonTest {
     private static final LessonName LESSON_NAME = new LessonName("Lecture");
-    private static final Day DAY_1 = Day.values()[Day.getTodayIntValue() + 1];
+    private static final Day DAY_1 = Day.values()[(Day.getTodayIntValue() + 1) % 7];
     private static final ModBookTime START_TIME_2 = new ModBookTime("09:30");
     private static final ModBookTime END_TIME_2 = new ModBookTime("11:30");
     private static final Timeslot TIMESLOT_2 = new Timeslot(START_TIME_2, END_TIME_2);
 
-    private static final Day DAY_2 = Day.values()[Day.getTodayIntValue() + 2];
+    private static final Day DAY_2 = Day.values()[(Day.getTodayIntValue() + 2) % 7];
     private static final ModBookTime START_TIME = new ModBookTime("09:00");
     private static final ModBookTime END_TIME = new ModBookTime("11:00");
     private static final Timeslot TIMESLOT = new Timeslot(START_TIME, END_TIME);


### PR DESCRIPTION
Fixes #146 , also fixes #145 and #139

Turns out the issue was Module using the abstract `List<>` to store lessons and exams, and in the first time using ModBook (without a `modbook.json` file), any list related methods are called on that, which causes problems since `List` is an abstract class without any concrete implementation. So it throws an error. 
The reason why closing ModBook and opening it again resolves the issue is because `JsonAdapatedModule` will read from the json file and then put the lessons/modules in a proper `ArrayList<>` so all the list related methods work on it. 

Also fixes the buggy LessonTest that caused problems regarding Day.

Let's:
- Make `Module` use an `ArrayList<>`, and adjust constructor accordingly
- Use modulos to prevent OOB error when initialising `Day` in `LessonTest`

You're welcome