### PR TITLE
Fix edit mod to be able to edit mod code

### DIFF
--- a/src/main/java/seedu/address/logic/commands/edit/EditModCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditModCommand.java
@@ -20,7 +20,6 @@ import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleName;
 import seedu.address.model.module.exam.Exam;
 import seedu.address.model.module.lesson.Lesson;
-import seedu.address.model.module.predicates.HasModuleCodePredicate;
 
 public class EditModCommand extends EditCommand {
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists.";
@@ -58,11 +57,7 @@ public class EditModCommand extends EditCommand {
         Module moduleToEdit = lastShownList.get(targetIndex.getZeroBased());
         Module editedModule = createEditedModule(moduleToEdit, editModDescriptor);
 
-        // check if module code is changed and if another module already has the new module code
-        HasModuleCodePredicate pred = new HasModuleCodePredicate(editedModule.getCode());
-        model.updateFilteredModuleList(pred);
-        if (!moduleToEdit.isSameModule(editedModule) && model.getFilteredModuleList().size() > 0) {
-            model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
+        if (!moduleToEdit.isSameModule(editedModule) && model.hasModule(editedModule)) {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
         }
 

--- a/src/main/java/seedu/address/logic/commands/edit/EditModCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditModCommand.java
@@ -20,6 +20,7 @@ import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleName;
 import seedu.address.model.module.exam.Exam;
 import seedu.address.model.module.lesson.Lesson;
+import seedu.address.model.module.predicates.HasModuleCodePredicate;
 
 public class EditModCommand extends EditCommand {
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists.";
@@ -57,7 +58,11 @@ public class EditModCommand extends EditCommand {
         Module moduleToEdit = lastShownList.get(targetIndex.getZeroBased());
         Module editedModule = createEditedModule(moduleToEdit, editModDescriptor);
 
-        if (!moduleToEdit.isSameModule(editedModule)) {
+        // check if module code is changed and if another module already has the new module code
+        HasModuleCodePredicate pred = new HasModuleCodePredicate(editedModule.getCode());
+        model.updateFilteredModuleList(pred);
+        if (!moduleToEdit.isSameModule(editedModule) && model.getFilteredModuleList().size() > 0) {
+            model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
         }
 


### PR DESCRIPTION
Fixes #171 

Previously for some reason whenever the edited module code is different from the original, it'll throw an error. Now it actually checks if a module with the same code as the edited module exists in the ModBook and throw an error based on that.

Let's:
- actually check the model to see whether a module is duplicated or not
- it's literally adding a single extra condition in the if statement