### PR TITLE
Special Module Codes

### DIFF
--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -12,14 +12,14 @@ public class ModuleCode {
      * "Each module of study has a unique module code consisting of a two‐ or three‐letter prefix
      * that denotes the discipline, and four digits, the first of which indicates the level of
      * the module (e.g., 1000 indicates a Level 1 module and 2000, a Level 2 module)."
-     * There is also an optional last character representing the course of study.
+     * There are also two optional last characters representing the course of study.
      * Reference: https://www.nus.edu.sg/registrar/academic-information-policies/non-graduating/modular-system
      */
-    public static final String VALIDATION_REGEX = "^([a-zA-Z]{2,3}[0-9]{4}[a-zA-Z]?)$";
+    public static final String VALIDATION_REGEX = "^([a-zA-Z]{2,3}[0-9]{4}[a-zA-Z]{0,2})$";
     public static final String MESSAGE_CONSTRAINTS =
-            "Module Code must have a two or three letter prefix that denotes disciple, four digits "
-                    + "which represents the level of the module, and an optional last character that "
-                    + "represents the course of study.";
+            "Module Code must have a two or three letter prefix that denotes the discipline, four digits "
+                    + "which represents the level of the module, and two optional characters at the end which "
+                    + "represent the course of study.";
     public final String moduleCode;
 
     /**

--- a/src/test/java/seedu/address/model/module/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleCodeTest.java
@@ -32,7 +32,8 @@ public class ModuleCodeTest {
         assertFalse(ModuleCode.isValidModuleCode("CS20S")); // two numbers only
         assertFalse(ModuleCode.isValidModuleCode("CS2S")); // one numbers only
         assertFalse(ModuleCode.isValidModuleCode("CS")); // no numbers
-        assertFalse(ModuleCode.isValidModuleCode("CS2040SS")); // two letter suffix
+        assertFalse(ModuleCode.isValidModuleCode("CS2040SSS")); // three letter suffix
+
 
         // valid module code
         assertTrue(ModuleCode.isValidModuleCode("cs2040s")); // lowercase alphabets only
@@ -41,6 +42,7 @@ public class ModuleCodeTest {
         assertTrue(ModuleCode.isValidModuleCode("CS2103")); // two letter with no ending letter
         assertTrue(ModuleCode.isValidModuleCode("CS2103T")); // two letter with ending letter
         assertTrue(ModuleCode.isValidModuleCode("DAO1000")); // three letter with no ending letter
+        assertTrue(ModuleCode.isValidModuleCode("UIS3951CS")); // two letter suffix
         assertTrue(ModuleCode.isValidModuleCode("DAO1000S")); // three letter with ending letter
     }
 }


### PR DESCRIPTION
Allow ModuleCode to accept 0-2 characters at the end to allow for special modules like UIS3951CS. This is for issue #167 