### PR TITLE
Do not parse invalid dates as nearest correct date

### DIFF
--- a/src/main/java/seedu/address/model/module/ModBookDate.java
+++ b/src/main/java/seedu/address/model/module/ModBookDate.java
@@ -7,6 +7,7 @@ import static seedu.address.commons.util.DateTimeUtil.buildFormatter;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Represents a date in the ModBook.
@@ -16,15 +17,15 @@ public class ModBookDate implements Comparable<ModBookDate> {
     public static final String MESSAGE_CONSTRAINTS =
             "Invalid date format. Please refer to the User Guide for valid date formats.";
     public static final DateTimeFormatter[] PARSE_FORMATTERS = new DateTimeFormatter[] {
-        buildFormatter("dd/MM/yyyy"),
-        buildFormatter("dd-MM-yyyy"),
-        buildFormatter("dd.MM.yyyy"),
-        buildFormatter("ddMMyyyy"),
-        buildFormatter("dd MM yyyy"),
-        buildFormatter("dd LLLL yyyy"),
-        buildFormatter("dd LLL yyyy"),
-        buildFormatter("d LLL yyyy"),
-        buildFormatter("d LLLL yyyy")
+        buildFormatter("dd/MM/uuuu"),
+        buildFormatter("dd-MM-uuuu"),
+        buildFormatter("dd.MM.uuuu"),
+        buildFormatter("ddMMuuuu"),
+        buildFormatter("dd MM uuuu"),
+        buildFormatter("dd LLLL uuuu"),
+        buildFormatter("dd LLL uuuu"),
+        buildFormatter("d LLL uuuu"),
+        buildFormatter("d LLLL uuuu")
     };
     public static final DateTimeFormatter PRINT_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     public final LocalDate date;
@@ -65,7 +66,7 @@ public class ModBookDate implements Comparable<ModBookDate> {
         LocalDate result = null;
         for (DateTimeFormatter f : PARSE_FORMATTERS) {
             try {
-                result = LocalDate.parse(test, f);
+                result = LocalDate.parse(test, f.withResolverStyle(ResolverStyle.STRICT));
                 break; // short circuit once valid formatter is found
             } catch (DateTimeParseException e) {
                 // do nothing

--- a/src/test/java/seedu/address/model/module/ModBookDateTest.java
+++ b/src/test/java/seedu/address/model/module/ModBookDateTest.java
@@ -41,8 +41,6 @@ public class ModBookDateTest {
         assertFalse(ModBookDate.isValidDate("29/02/2021"));
         assertFalse(ModBookDate.isValidDate("31/06/2021"));
 
-
-
         // valid dates
         assertTrue(ModBookDate.isValidDate("19 Sep 2021")); // use of month abbreviations
         assertTrue(ModBookDate.isValidDate("19-02-2012")); // use of hyphens

--- a/src/test/java/seedu/address/model/module/ModBookDateTest.java
+++ b/src/test/java/seedu/address/model/module/ModBookDateTest.java
@@ -38,6 +38,10 @@ public class ModBookDateTest {
         assertFalse(ModBookDate.isValidDate("6pm 12/12/2021")); // including time of day
         assertFalse(ModBookDate.isValidDate("09|09|2021"));
         assertFalse(ModBookDate.isValidDate("09,09,2021"));
+        assertFalse(ModBookDate.isValidDate("29/02/2021"));
+        assertFalse(ModBookDate.isValidDate("31/06/2021"));
+
+
 
         // valid dates
         assertTrue(ModBookDate.isValidDate("19 Sep 2021")); // use of month abbreviations


### PR DESCRIPTION
Solves issue#137.

DateTimeFormatter has three options when resolving dates and times which are LENIENT, SMART(default) and STRICT. 

Lets:
1. Ensure that DateTimeFormatter resolves the date under strict mode so that it doesn't round off invalid dates the the nearest valid date. 
2. Change year symbol from yyyy to uuuu as required by the strict resolver.