### PR TITLE
Fix edit command timeslot

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -113,7 +113,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         // Prevent users from inputting only either the start or the end timings
-        if ((argMultimap.getValue(PREFIX_START).isPresent() ^ argMultimap.getValue(PREFIX_END).isPresent())) {
+        if (argMultimap.getValue(PREFIX_START).isPresent() ^ argMultimap.getValue(PREFIX_END).isPresent()) {
             throw new ParseException(MESSAGE_INVALID_TIMESLOT);
         }
 
@@ -163,7 +163,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         // Prevent users from inputting only either the start or the end timings
-        if ((argMultimap.getValue(PREFIX_START).isPresent() ^ argMultimap.getValue(PREFIX_END).isPresent())) {
+        if (argMultimap.getValue(PREFIX_START).isPresent() ^ argMultimap.getValue(PREFIX_END).isPresent()) {
             throw new ParseException(MESSAGE_INVALID_TIMESLOT);
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -27,6 +27,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new EditCommand object
  */
 public class EditCommandParser implements Parser<EditCommand> {
+    public static final String MESSAGE_INVALID_TIMESLOT =
+            "Both start and end timings have to be present to modify the timeslot.";
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
@@ -110,7 +112,11 @@ public class EditCommandParser implements Parser<EditCommand> {
             editLessonDescriptor.setDay(ParserUtil.parseDay(argMultimap.getValue(PREFIX_DAY).get()));
         }
 
-        // TODO: Need to deal with case where only start or end time is given. Currently assume both given.
+        // Prevent users from inputting only either the start or the end timings
+        if ((argMultimap.getValue(PREFIX_START).isPresent() ^ argMultimap.getValue(PREFIX_END).isPresent())) {
+            throw new ParseException(MESSAGE_INVALID_TIMESLOT);
+        }
+
         if (argMultimap.getValue(PREFIX_START).isPresent() && argMultimap.getValue(PREFIX_END).isPresent()) {
             editLessonDescriptor.setTimeslot(ParserUtil.parseTimeslot(argMultimap.getValue(PREFIX_START).get(),
                     argMultimap.getValue(PREFIX_END).get()));
@@ -156,7 +162,11 @@ public class EditCommandParser implements Parser<EditCommand> {
             editExamDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
         }
 
-        // TODO: Need to deal with case where only start or end time is given. Currently assume both given.
+        // Prevent users from inputting only either the start or the end timings
+        if ((argMultimap.getValue(PREFIX_START).isPresent() ^ argMultimap.getValue(PREFIX_END).isPresent())) {
+            throw new ParseException(MESSAGE_INVALID_TIMESLOT);
+        }
+
         if (argMultimap.getValue(PREFIX_START).isPresent() && argMultimap.getValue(PREFIX_END).isPresent()) {
             editExamDescriptor.setTimeslot(ParserUtil.parseTimeslot(argMultimap.getValue(PREFIX_START).get(),
                     argMultimap.getValue(PREFIX_END).get()));

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -176,4 +176,27 @@ public class EditCommandParserTest {
                 GuiState.EXAMS, MESSAGE_WRONG_VIEW_DETAILS);
     }
 
+    /**
+     * Editing timeslot of lesson/exam requires both fields present
+     */
+    @Test
+    public void parse_invalidTimeslot_throwsParseException() {
+        Module module = new ModuleBuilder(CS2103T).withDefaultName().build();
+
+        // Test with only start and end time of lesson
+        assertParseFailure(parser, " lesson " + INDEX_FIRST_LESSON.getOneBased() + " " + PREFIX_CODE
+                        + module.getCode() + " " + "s/1200",
+                GuiState.DETAILS, EditCommandParser.MESSAGE_INVALID_TIMESLOT);
+        assertParseFailure(parser, " lesson " + INDEX_FIRST_LESSON.getOneBased() + " " + PREFIX_CODE
+                        + module.getCode() + " " + "e/1200",
+                GuiState.DETAILS, EditCommandParser.MESSAGE_INVALID_TIMESLOT);
+
+        // Test with only start and end time of exam
+        assertParseFailure(parser, " exam " + INDEX_FIRST_EXAM.getOneBased() + " " + PREFIX_CODE
+                        + module.getCode() + " " + "s/1200",
+                GuiState.DETAILS, EditCommandParser.MESSAGE_INVALID_TIMESLOT);
+        assertParseFailure(parser, " exam " + INDEX_FIRST_EXAM.getOneBased() + " " + PREFIX_CODE
+                        + module.getCode() + " " + "e/1200",
+                GuiState.DETAILS, EditCommandParser.MESSAGE_INVALID_TIMESLOT);
+    }
 }


### PR DESCRIPTION
Let's:
- Fix issue with parsing input when only start/end time of an exam/lesson are modified

Fixes:
- #142 
- #144 
- #153 
- #164 