### PR TITLE
Make Edit and Delete only look at preamble instead of whole command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -103,7 +103,10 @@ See all the exams of all modules.
   - E.g. If you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
 - Extra parameters for commands that do not take in parameters (such as `help`, `exit` and `clear`) will be ignored.
   - E.g. If you type the command `help 123`, it will be interpreted as `help`.
-- For commands which expect indexes, the last integer given, if any, will be used as the input argument. Any non-integer values given will be ignored.
+- For commands which expect indexes, the index must be before any parameter prefix (e.g. `c/`, `s/`) specified
+  - E.g. If you specify `edit mod 1 c/CS1231S`, you would change the module code of the first module to CS1231S.
+  - However, If you specify `edit mod c/CS1231S 1`, you would get an error
+- In addition, the last integer given, if any, will be used as the input argument. Any non-integer values given will be ignored.
   - If you specify `delete lesson 1 3 2`, only `2` will be taken as the index.
   - If you specify `delete lesson 1 3 a b`, only `3` will be taken as the index.
   - Note that this effectively means that even if your last integer is invalid, it will be taken to be the index. E.g. if you specify `delete lesson 1 2 -1`, the invalid integer `-1` will be taken as the index.

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LINK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENUE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.GuiState;
@@ -45,7 +51,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         if (guiState != GuiState.SUMMARY) {
             throw new GuiStateException(GuiState.SUMMARY);
         }
-        Index index = ParserUtil.parseLastIndex(args);
+
+        // defensive coding to guard against users who erroneously add extra prefixes which may cause it to mess up
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DAY,
+                PREFIX_START, PREFIX_END, PREFIX_LINK, PREFIX_VENUE);
+        Index index = ParserUtil.parseLastIndex(argMultimap.getPreamble());
         return new DeleteModCommand(index);
     }
 
@@ -58,7 +68,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         if (guiState != GuiState.DETAILS) {
             throw new GuiStateException(GuiState.DETAILS);
         }
-        Index index = ParserUtil.parseLastIndex(args);
+
+        // defensive coding to guard against users who erroneously add extra prefixes which may cause it to mess up
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DAY,
+                PREFIX_START, PREFIX_END, PREFIX_LINK, PREFIX_VENUE);
+        Index index = ParserUtil.parseLastIndex(argMultimap.getPreamble());
         return new DeleteLessonCommand(index);
     }
 
@@ -71,7 +85,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         if (guiState != GuiState.DETAILS) {
             throw new GuiStateException(GuiState.DETAILS);
         }
-        Index index = ParserUtil.parseLastIndex(args);
+
+        // defensive coding to guard against users who erroneously add extra prefixes which may cause it to mess up
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DAY,
+                PREFIX_START, PREFIX_END, PREFIX_LINK, PREFIX_VENUE);
+        Index index = ParserUtil.parseLastIndex(argMultimap.getPreamble());
         return new DeleteExamCommand(index);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -64,7 +64,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CODE, PREFIX_NAME);
-        Index index = ParserUtil.parseLastIndex(args);
+        Index index = ParserUtil.parseLastIndex(argMultimap.getPreamble());
 
         if (!(ParserUtil.arePrefixesPresent(argMultimap, PREFIX_CODE)
                 || ParserUtil.arePrefixesPresent(argMultimap, PREFIX_NAME))) {
@@ -100,7 +100,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DAY,
                 PREFIX_START, PREFIX_END, PREFIX_LINK, PREFIX_VENUE);
-        Index index = ParserUtil.parseLastIndex(args);
+        Index index = ParserUtil.parseLastIndex(argMultimap.getPreamble());
 
         EditLessonDescriptor editLessonDescriptor = new EditLessonDescriptor();
 
@@ -147,10 +147,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (guiState != GuiState.DETAILS) {
             throw new GuiStateException(GuiState.DETAILS);
         }
-        Index index = ParserUtil.parseLastIndex(args);
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DATE,
                 PREFIX_START, PREFIX_END, PREFIX_LINK, PREFIX_VENUE);
+        Index index = ParserUtil.parseLastIndex(argMultimap.getPreamble());
 
         EditExamDescriptor editExamDescriptor = new EditExamDescriptor();
 


### PR DESCRIPTION
Fixes #169 

The problem with #169 is that parseLastIndex looked at the entire command, which is why it parsed in 2020 and returned the error message. 

Let's:
- Make EditCommandParser only look for indexes at the preamble (before any prefix)
- Do the same thing for DeleteCommandParser to prevent errors like this from either silly or malicious users
- Edit UG to document this behaviour