### PR TITLE
Disallow 2400 as an input for time

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -314,6 +314,21 @@ The following formats are valid for entering day values:
 | Saturday    | `Saturday`, `Sat`                  |
 | Sunday      | `Sunday`, `Sun`                    |
 
+The formats are case-insensitive, i.e. both `Monday` and `mon` are valid.
+
+The date and time formats accepted by ModBook use the symbols in the table below:
+
+| Symbol | Meaning                                 |
+| ------ | --------------------------------------- |
+| H      | Hour of 24-hour time. Goes from 0 to 23 |
+| h      | Hour of 12-hour time. Goes from 1 to 12 |
+| m      | Minute                                  |
+| a      | AM/PM indicator                         |
+| L      | Month as text                           |
+| M      | Month as number                         |
+| y      | Year                                    |
+| d      | day of month                            |
+
 The following formats are valid for entering date values:
 
 | Format         | Examples           |
@@ -327,19 +342,6 @@ The following formats are valid for entering date values:
 | `dd LLL yyyy`  | `02 Feb 1999`      |
 | `d LLLL yyyy`  | `2 february 1999`  |
 | `d LLL yyyy`   | `2 feb 1999`       |
-
-The meaning of the symbols in the formats specified are in the table below:
-
-| Symbol | Meaning                                 |
-| ------ | --------------------------------------- |
-| H      | Hour of 24-hour time. Goes from 0 to 23 |
-| h      | Hour of 12-hour time. Goes from 1 to 12 |
-| m      | Minute                                  |
-| a      | AM/PM indicator                         |
-| L      | Month as text                           |
-| M      | Month as number                         |
-| y      | Year                                    |
-| d      | day of month                            |
 
 The following formats are valid for entering time values:
 
@@ -355,7 +357,7 @@ The following formats are valid for entering time values:
 | `h.mma`  | `9.00AM`, `2.30pm`   |
 | `hh.mma` | `09.00AM`, `11.30pm` |
 
-The input for `AM/PM` is case-insensitive, e.g. both `10AM` and `10am` are valid.
+The input for `AM/PM` is case-insensitive, e.g. both `10AM` and `10am` are valid. Also, note that `2400` (i.e. midnight of the next day) is not a valid input.
 
 ## Command Summary
 

--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -2,16 +2,18 @@ package seedu.address.commons.util;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
 
 public class DateTimeUtil {
 
     /**
-     * Returns a case-insensitive DateTimeFormatter according to the given pattern
+     * Returns a case-insensitive DateTimeFormatter according to the given pattern with a Strict resolver style
      */
     public static DateTimeFormatter buildFormatter(String pattern) {
         return new DateTimeFormatterBuilder()
                 .parseCaseInsensitive()
                 .appendPattern(pattern)
-                .toFormatter();
+                .toFormatter()
+                .withResolverStyle(ResolverStyle.STRICT);
     }
 }

--- a/src/main/java/seedu/address/model/module/ModBookDate.java
+++ b/src/main/java/seedu/address/model/module/ModBookDate.java
@@ -7,7 +7,6 @@ import static seedu.address.commons.util.DateTimeUtil.buildFormatter;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.format.ResolverStyle;
 
 /**
  * Represents a date in the ModBook.
@@ -66,7 +65,7 @@ public class ModBookDate implements Comparable<ModBookDate> {
         LocalDate result = null;
         for (DateTimeFormatter f : PARSE_FORMATTERS) {
             try {
-                result = LocalDate.parse(test, f.withResolverStyle(ResolverStyle.STRICT));
+                result = LocalDate.parse(test, f);
                 break; // short circuit once valid formatter is found
             } catch (DateTimeParseException e) {
                 // do nothing

--- a/src/test/java/seedu/address/model/module/ModBookTimeTest.java
+++ b/src/test/java/seedu/address/model/module/ModBookTimeTest.java
@@ -40,6 +40,7 @@ class ModBookTimeTest {
         assertFalse(ModBookTime.isValidTime("14:98")); // minutes out of range
         assertFalse(ModBookTime.isValidTime("16:00:01")); // including seconds value
         assertFalse(ModBookTime.isValidTime("16:00:01.1234")); // including seconds and decimal value
+        assertFalse(ModBookTime.isValidTime("24:00")); // strict resolver would not parse this
 
         // valid times
         assertTrue(ModBookTime.isValidTime("16:00"));


### PR DESCRIPTION
This fixes issue 4 in [Wilbur's group's document](https://docs.google.com/document/d/1QOUpb2ewtv17ofnzyJ0aCmMm8GcQbQTFohCTia1u45E/edit)

The issue was caused by the ResolverStyle in the DateTimeFormatter being Smart, resulting in [this behaviour](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#parsedExcessDays--)

Let's
- Make the DateTimeFormatter returned by buildFormatter to use a Strict ResolverStyle by default (because parseDate in ModBookDate also uses a Strict ResolverStyle)
- Update the UG to reflect this behaviour